### PR TITLE
デプロイ先をec2に変更するためにS3バケットをheroku用とは別のものに変更

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -6,8 +6,10 @@ CarrierWave.configure do |config|
   if Rails.env.production? || Rails.env.development? # 開発中もs3使う
     config.storage :fog
     config.fog_provider = 'fog/aws'
-    config.fog_directory  = 'petlog-bucket'
-    config.asset_host = 'https://s3.amazonaws.com/petlog-bucket'
+    #config.fog_directory  = 'petlog-bucket'
+    config.fog_directory  = 'petlog-ec2'
+    #config.asset_host = 'https://s3.amazonaws.com/petlog-bucket'
+    config.asset_host = 'https://s3.amazonaws.com/petlog-ec2'
     # NOTE: AWS側の設定を変えなくても、この１行の設定でアップロードできた
     config.fog_public = false # ←コレ
     config.fog_credentials = {


### PR DESCRIPTION
本番環境をherokuからEC2に変更するにあたり、herokuからデータベースは引き継がず、新規で始める事にした。
画像の保存先も新規のS3バケット(petlog-ec2)を設け、そちらを使用する事とする。